### PR TITLE
Pin SQLitePCLRaw native SQLite to 3.50.3 (fix CVE-2025-6965)

### DIFF
--- a/.github/workflows/dotnet-core.yml
+++ b/.github/workflows/dotnet-core.yml
@@ -22,7 +22,7 @@ jobs:
     steps:
     - name: Disable disk flush for CI
       run: sudo apt-get install -y libeatmydata1
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@v7
       with:
         submodules: recursive
     - name: Setup .NET Core

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -19,6 +19,8 @@
 
     <!-- Enable Central Package Management -->
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+    <!-- Allow pinning transitive package versions centrally (used to override vulnerable transitive deps) -->
+    <CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>
 
     <!-- AOT compatibility disabled in Directory.Build.targets (reflection-heavy library) -->
 

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -5,6 +5,10 @@
   <ItemGroup>
     <!-- Main dependencies -->
     <PackageVersion Include="fo-dicom" Version="5.2.6" />
+    <!-- Transitive pin: override vulnerable native SQLite (CVE-2025-6965 / GHSA-2m69-gcr7-jv3q,
+         affects SQLitePCLRaw.lib.e_sqlite3 <= 2.1.11) pulled in via FAnsiSql.Legacy ->
+         FAnsiSql.Sqlite -> Microsoft.Data.Sqlite. 3.50.3 bundles SQLite >= 3.50.2. -->
+    <PackageVersion Include="SQLitePCLRaw.lib.e_sqlite3" Version="3.50.3" />
     <PackageVersion Include="FAnsiSql.Legacy" Version="3.6.3" />
     <PackageVersion Include="MongoDB.Bson" Version="3.9.0" />
     <PackageVersion Include="YamlDotNet" Version="18.0.0" />

--- a/PACKAGES.md
+++ b/PACKAGES.md
@@ -13,6 +13,7 @@
 | MongoDB.Bson | [GitHub](https://github.com/mongodb/mongo-csharp-driver) | [Apache 2.0](http://www.apache.org/licenses/LICENSE-2.0) | BSON serialization for writing dicom tags to MongoDb databases|
 | fo-dicom | [GitHub](https://github.com/fo-dicom/fo-dicom) | [MS-PL](https://opensource.org/licenses/MS-PL) | Handles reading/writing dicom tags from dicom datasets | |
 | YamlDotNet | [GitHub](https://github.com/aaubry/YamlDotNet) | [MIT](https://opensource.org/licenses/MIT) | Loading configuration files|
+| SQLitePCLRaw.lib.e_sqlite3 | [GitHub](https://github.com/ericsink/SQLitePCL.raw) | [Apache 2.0](http://www.apache.org/licenses/LICENSE-2.0) | Transitive pin of the native SQLite binary (via FAnsiSql.Sqlite/Microsoft.Data.Sqlite) to 3.50.3 to fix CVE-2025-6965 | Pinned to override a vulnerable transitive version |
 
 ## Build Tools (PrivateAssets)
 


### PR DESCRIPTION
## Problem
`SQLitePCLRaw.lib.e_sqlite3` 2.1.11 (bundled native SQLite) is flagged by **CVE-2025-6965 / GHSA-2m69-gcr7-jv3q** (high severity — memory corruption in SQLite < 3.50.2), causing `dotnet restore` to fail with `NU1903` (warning-as-error).

It is pulled in transitively:
```
FAnsiSql.Legacy → FAnsiSql.Sqlite → Microsoft.Data.Sqlite 10.0.1
  → SQLitePCLRaw.bundle_e_sqlite3 2.1.11 → SQLitePCLRaw.lib.e_sqlite3 2.1.11
```

## Fix
- Central transitive pin of `SQLitePCLRaw.lib.e_sqlite3` to **3.50.3** (bundles SQLite 3.50.3, > 3.50.2).
- Enable `CentralPackageTransitivePinningEnabled` so the pin overrides the transitive version.

## Verification
- `dotnet restore` — clean, no NU1903.
- `dotnet nuget why` — resolves to `SQLitePCLRaw.lib.e_sqlite3 (v3.50.3)`.
- `dotnet build -c Release` — succeeded, 0 warnings / 0 errors.
- Runtime smoke test (new native 3.50.3 + existing managed core 2.1.11) — `SQLite native version: 3.50.3`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pins `SQLitePCLRaw.lib.e_sqlite3` to 3.50.3 to fix CVE-2025-6965 (GHSA-2m69-gcr7-jv3q) and stop `dotnet restore` from failing with `NU1903`. Also documents the pin in `PACKAGES.md` and updates CI to `actions/checkout@v7`.

- **Bug Fixes**
  - Centrally pin `SQLitePCLRaw.lib.e_sqlite3` to 3.50.3 and enable `CentralPackageTransitivePinningEnabled` so it overrides the vulnerable transitive version from `FAnsiSql.Legacy` → `FAnsiSql.Sqlite` → `Microsoft.Data.Sqlite` → `SQLitePCLRaw.bundle_e_sqlite3`.

- **Dependencies**
  - Bump `actions/checkout` from v6 to v7.

<sup>Written for commit 11ac9524c6a606e3993697e4e16a45f0414b092a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/jas88/DicomTypeTranslation/pull/91?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

